### PR TITLE
introduce reifyScope as alias for asyncScope

### DIFF
--- a/cats-effect/shared/src/main/scala/cps/monads/catsEffect/ResourceCpsMonad.scala
+++ b/cats-effect/shared/src/main/scala/cps/monads/catsEffect/ResourceCpsMonad.scala
@@ -49,3 +49,8 @@ class AsyncScopeInferArg[F[_],C <: CpsMonadContext[[A]=>>Resource[F,A]]](using a
  */
 def asyncScope[F[_]](using m:CpsTryMonad[[A]=>>Resource[F,A]], mc:MonadCancel[F,Throwable]) = AsyncScopeInferArg(using m, mc)
 
+/**
+ * Synonym for `asyncScope`.
+ **/
+def reifyScope[F[_]](using m:CpsTryMonad[[A]=>>Resource[F,A]], mc:MonadCancel[F,Throwable]) = AsyncScopeInferArg(using m, mc)
+


### PR DESCRIPTION
I really like the alternative names (`reify`/`reflect`/`!`) and prefer them over the common async/await. Therefore, I thought, it makes sense to also have the `reifyScope` alias for `asyncScope`. This allow for consistent naming.
